### PR TITLE
Use PyPDF2 for final merge

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -12,6 +12,7 @@ gunicorn = "*"
 flask-scss = "*"
 requests = "*"
 fdfgen = "*"
+"pypdf2" = "*"
 
 
 [dev-packages]

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "846e875e58194b6297c90c06252481007a78ed31f561b15a6ab89d9ebcad59b5"
+            "sha256": "49c2b19cddf2e7c48ba63513cce07c3bf615b12bf6691215e4495b3e322f1cb3"
         },
         "host-environment-markers": {
             "implementation_name": "cpython",
@@ -78,10 +78,10 @@
         },
         "idna": {
             "hashes": [
-                "sha256:8c7309c718f94b3a625cb648ace320157ad16ff131ae0af362c9f21b80ef6ec4",
-                "sha256:2c6a5de3089009e3da7c5dde64a141dbc8551d5b7f6cf4ed7c2568d0cc520a8f"
+                "sha256:156a6814fb5ac1fc6850fb002e0852d56c0c8d2531923a51032d1b70760e186e",
+                "sha256:684a38a6f903c1d71d6d5fac066b58d7768af4de2b832e426ec79c30daa94a16"
             ],
-            "version": "==2.6"
+            "version": "==2.7"
         },
         "itsdangerous": {
             "hashes": [
@@ -102,6 +102,12 @@
             ],
             "version": "==1.0"
         },
+        "pypdf2": {
+            "hashes": [
+                "sha256:e28f902f2f0a1603ea95ebe21dff311ef09be3d0f0ef29a3e44a932729564385"
+            ],
+            "version": "==1.26.0"
+        },
         "pyscss": {
             "hashes": [
                 "sha256:14a25c33c221a66bb1f000a6a067f376528d3df2f9333cee9c95709a9280cdb0"
@@ -110,10 +116,10 @@
         },
         "requests": {
             "hashes": [
-                "sha256:6a1b267aa90cac58ac3a765d067950e7dbbf75b1da07e895d1f594193a40a38b",
-                "sha256:9c443e7324ba5b85070c4a818ade28bfabedf16ea10206da1132edaa6dda237e"
+                "sha256:63b52e3c866428a224f97cab011de738c36aec0185aa91cfacd418b5d58911d1",
+                "sha256:ec22d826a36ed72a7358ff3fe56cbd4ba69dd7a6718ffd450ff0e9df7a47ce6a"
             ],
-            "version": "==2.18.4"
+            "version": "==2.19.1"
         },
         "six": {
             "hashes": [
@@ -124,10 +130,10 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:06330f386d6e4b195fbfc736b297f58c5a892e4440e54d294d7004e3a9bbea1b",
-                "sha256:cc44da8e1145637334317feebd728bd869a35285b93cbb4cca2577da7e62db4f"
+                "sha256:b5725a0bd4ba422ab0e66e89e030c806576753ea3ee08554382c14e685d117b5",
+                "sha256:a68ac5e15e76e7e5dd2b8f94007233e01effe3e50e8daddf69acfd81cb686baf"
             ],
-            "version": "==1.22"
+            "version": "==1.23"
         },
         "werkzeug": {
             "hashes": [

--- a/lament_mod/character.py
+++ b/lament_mod/character.py
@@ -11,7 +11,7 @@ class LotFPCharacter(object):
         self.counter = counter
         self.pcClass = self.details['class']
 
-        self.name = ' - '.join([str(self.counter + 1), self.pcClass])
+        self.name = '_'.join([str(self.counter + 1), self.pcClass])
         self.fdf_name = self.name + '.fdf'
         self.filled_name = self.name + '_Filled.pdf'
 

--- a/lament_mod/lament.py
+++ b/lament_mod/lament.py
@@ -5,8 +5,10 @@ from flask import request, send_file, render_template, flash, url_for, redirect,
 import lament_mod.character as character
 import lament_mod.tools as tools
 from fdfgen import forge_fdf
+from PyPDF2 import PdfFileMerger, PdfFileReader
 import subprocess
 import os
+import glob
 import tempfile
 import random
 
@@ -125,12 +127,13 @@ def lament_pdf():
     if os.path.exists(final_name):
         os.remove(final_name)
 
-    subprocess.run([path_to_pdftk,
-                    os.path.join(tmpdir.name, '*.pdf'),
-                    'cat',
-                    'output',
-                    final_name],
-                   **tools.subprocess_args(False))
+    merger = PdfFileMerger()
+    PDFs_to_be_merged = glob.glob(os.path.join(tmpdir.name, '*.pdf'))
+
+    for PDF in PDFs_to_be_merged:
+        merger.append(PdfFileReader(open(PDF, 'rb')))
+
+    merger.write(final_name)
 
     return send_file(final_name,
                      mimetype="application/pdf",


### PR DESCRIPTION
This will refactor Lament to use PyPDF2 for the final merger of combined PDFs. This avoids a few problems with pdftk and shell wildcard expansion.